### PR TITLE
Fix `insertAll` to correctly keep cache state

### DIFF
--- a/Binding/src/main/scala/com/thoughtworks/binding/Binding.scala
+++ b/Binding/src/main/scala/com/thoughtworks/binding/Binding.scala
@@ -943,7 +943,7 @@ object Binding extends MonadicFactory.WithTypeClass[Monad, Binding] {
         } {
           listener.patched(new PatchedEvent(Vars.this, cache, n, seq, 0))
         }
-        cache.patch(n, seq, 0)
+        cache = cache.patch(n, seq, 0)
       }
 
       override def iterator: Iterator[A] = {


### PR DESCRIPTION
`Buffer#patch` creates a new buffer, instead of modifying the current one. Since the code wasn't reassigning the new buffer to the old variable, the state is inconsistent.

Fixes #9