### PR TITLE
remove unused referenceCount

### DIFF
--- a/Binding/src/main/scala/com/thoughtworks/binding/Binding.scala
+++ b/Binding/src/main/scala/com/thoughtworks/binding/Binding.scala
@@ -1030,8 +1030,6 @@ object Binding extends MonadicFactory.WithTypeClass[Monad, Binding] {
 
     protected def set(value: Value): Unit
 
-    private var referenceCount = 0
-
     private[binding] final def mount(): Unit = {
       set(upstream.get)
       upstream.addChangedListener(upstreamListener)


### PR DESCRIPTION
var `referenceCount` is defined in `MountPoint`.