### PR TITLE
Option[Node] support

### DIFF
--- a/dom/src/main/scala/com/thoughtworks/binding/dom.scala
+++ b/dom/src/main/scala/com/thoughtworks/binding/dom.scala
@@ -155,6 +155,9 @@ object dom {
     def domBindingSeq(text: String) = Constants(document.createTextNode(text))
 
     @inline
+    def domBindingSeq(optionNode: Option[Node]) = Constants(optionNode.toSeq: _*)
+
+    @inline
     def notEqual[A](left: A, right: A) = left != right
   }
 

--- a/dom/src/test/scala/com/thoughtworks/binding/domTest.scala
+++ b/dom/src/test/scala/com/thoughtworks/binding/domTest.scala
@@ -325,5 +325,30 @@ final class domTest extends FreeSpec with Matchers {
     @dom def mySelect = <br class=""/>
   }
 
+  "Option" in {
+    val warning = Var(true)
+    @dom val text = if(warning.bind) Some(<b>warning</b>) else None
+
+    @dom val div = <div>{text.bind}</div>
+    div.watch()
+
+    assert(div.value.outerHTML == "<div><b>warning</b></div>")
+    warning.value = false
+    assert(div.value.outerHTML == "<div/>")
+  }
+
+  "OptionMonadicExpression" in {
+    import scalaz.std.option._
+    val firstName = Var[scala.Option[String]](Some("firstName"))
+    @dom val text = firstName.bind.map(text => <span>{text}</span>)
+
+    @dom val div = <div>{text.bind}</div>
+    div.watch()
+
+    assert(div.value.outerHTML == "<div><span>firstName</span></div>")
+    firstName.value = None
+    assert(div.value.outerHTML == "<div/>")
+  }
+
 }
 


### PR DESCRIPTION
I have seen this Q&A about creating a Binding of HTML node conditionally:
https://stackoverflow.com/questions/42660538/how-do-i-create-a-binding-of-html-node-conditionally

I suppose, this is more ideomatic way:
```scala
@dom def maybeEmpty: Binding[Option[Node]] = {
  if (math.random > 0.5) {
    Some(<div>non-empty content</div>)
  } else {
    None
  }
}
```