### PR TITLE
Fix parsing hash on mount of Route.Hash

### DIFF
--- a/Route/src/main/scala/com/thoughtworks/binding/Route.scala
+++ b/Route/src/main/scala/com/thoughtworks/binding/Route.scala
@@ -88,8 +88,8 @@ object Route {
     }
 
     override protected def mount(): Unit = {
-      super.mount()
       updateState()
+      super.mount()
       window.addEventListener("hashchange", listener)
     }
 

--- a/Route/src/test/scala/com/thoughtworks/binding/RouteSpec.scala
+++ b/Route/src/test/scala/com/thoughtworks/binding/RouteSpec.scala
@@ -9,6 +9,7 @@ import org.scalajs.dom.window
   */
 final class RouteSpec extends FreeSpec with Matchers {
   "route" in {
+    window.location.hash = "#[]"
     val route = Route.Hash[Option[Int]](None)
     route.watch()
     window.location.hash should be("#[]")
@@ -20,5 +21,14 @@ final class RouteSpec extends FreeSpec with Matchers {
     window.location.hash = "#[]"
     route.updateState()
     route.state.value should be(None)
+  }
+
+  "route should parse hash on mount" in {
+    window.location.hash = "#[123]"
+
+    val route = Route.Hash[Option[Int]](None)
+    route.watch()
+
+    route.state.value should be(Some(123))
   }
 }


### PR DESCRIPTION
I suppose, this commit: https://github.com/ThoughtWorksInc/Binding.scala/commit/acf5d84827b969b2cc9b8d94aaaefb909caa2022 broke initial parsing of `window.location.hash`. Because of this a link like https://ccamel.github.io/playground-binding.scala/index.html#playground-binding.scala/calc always opens default page.