### PR TITLE
Revert "Update extractor to 2.1.1"

### DIFF
--- a/dom/build.sbt
+++ b/dom/build.sbt
@@ -6,7 +6,7 @@ name := "dom"
 
 description := "Reactive web framework for Scala.js."
 
-libraryDependencies += "com.thoughtworks.extractor" %% "extractor" % "2.1.1"
+libraryDependencies += "com.thoughtworks.extractor" %% "extractor" % "1.2.0"
 
 libraryDependencies += "com.lihaoyi" %%% "scalatags" % "0.6.7"
 


### PR DESCRIPTION
Reverts ThoughtWorksInc/Binding.scala#99 since it breaks backward-compatibility