### PR TITLE
Special syntax to disable tag name checking

### DIFF
--- a/dom/src/main/scala/com/thoughtworks/binding/dom.scala
+++ b/dom/src/main/scala/com/thoughtworks/binding/dom.scala
@@ -39,6 +39,8 @@ import scala.language.experimental.macros
 import scalatags.JsDom
 import scalatags.jsdom
 import org.scalajs.dom.document
+import scalatags.JsDom.TypedTag
+import scalatags.generic.Namespace
 
 import scala.collection.immutable.Queue
 import scala.reflect.NameTransformer
@@ -144,13 +146,15 @@ object dom {
 
       import scala.language.dynamics
 
-      object raw extends Dynamic {
-
+      final class DynamicDataTag private[TagsAndTags2] ()
+          extends TypedTag[HTMLElement]("data", Nil, false, Namespace.htmlNamespaceConfig)
+          with Dynamic {
         final def selectDynamic(tagName: String): ConcreteHtmlTag[Element] = {
-          tag(tagName)
+          TagsAndTags2.tag(tagName)
         }
-
       }
+
+      override lazy val data = new DynamicDataTag()
 
     }
 

--- a/dom/src/test/scala/com/thoughtworks/binding/domTest.scala
+++ b/dom/src/test/scala/com/thoughtworks/binding/domTest.scala
@@ -437,5 +437,15 @@ final class domTest extends FreeSpec with Matchers {
     assert(div.value.className == "DIV-1")
   }
 
+  "CustomTag" in {
+    @dom def tag = {
+      <raw:custom-tag local-id="customTag" id="custom" data:custom-key="value"><data id="123">{customTag.tagName}</data></raw:custom-tag>
+    }
+    val div = document.createElement("div")
+    dom.render(div, tag)
+
+    assert(div.outerHTML == """<div><custom-tag custom-key="value" id="custom"><data id="123">CUSTOM-TAG</data></custom-tag></div>""")
+  }
+
 }
 

--- a/dom/src/test/scala/com/thoughtworks/binding/domTest.scala
+++ b/dom/src/test/scala/com/thoughtworks/binding/domTest.scala
@@ -439,7 +439,7 @@ final class domTest extends FreeSpec with Matchers {
 
   "CustomTag" in {
     @dom def tag = {
-      <raw:custom-tag local-id="customTag" id="custom" data:custom-key="value"><data id="123">{customTag.tagName}</data></raw:custom-tag>
+      <data:custom-tag local-id="customTag" id="custom" data:custom-key="value"><data id="123">{customTag.tagName}</data></data:custom-tag>
     }
     val div = document.createElement("div")
     dom.render(div, tag)


### PR DESCRIPTION
Introducing a special syntax to disable tag name checking (https://github.com/ThoughtWorksInc/Binding.scala/issues/43#issuecomment-281709586):
```scala
@dom def tag = <raw:custom-tag/>
```
Unfortunately, it is not possible to use the same syntax as for attributes, because `data` name is already busy (there is `data` html tag).

I have selected a `raw:` prefix (similar to `raw"""   """` string interpolator :) )