### PR TITLE
poc of cats-effect async binding

### DIFF
--- a/AsyncBinding/build.sbt.shared
+++ b/AsyncBinding/build.sbt.shared
@@ -1,0 +1,10 @@
+organization := "com.thoughtworks.binding"
+
+name := "AsyncBinding"
+
+libraryDependencies += "org.typelevel" %%% "cats-effect" % "1.1.0"
+
+scalacOptions += "-feature"
+
+// Enable SAM type
+scalacOptions += "-Xexperimental"

--- a/AsyncBinding/src/main/scala/com/thoughtworks/binding/async/AsyncBinding.scala
+++ b/AsyncBinding/src/main/scala/com/thoughtworks/binding/async/AsyncBinding.scala
@@ -1,0 +1,28 @@
+package com.thoughtworks.binding.async
+
+import cats.effect.{Effect, IO, SyncIO}
+import com.thoughtworks.binding.Binding
+import com.thoughtworks.binding.Binding.Var
+
+
+class AsyncBinding[T, F[_] : Effect](task: F[T]) extends Binding[AsyncState[T]] {
+
+  private val state: Var[AsyncState[T]] = Var(AsyncState.NotStarted)
+
+  def refresh(): Unit = {
+    val start = Effect[F].runAsync(task) {
+      case Left(err) => IO(state.value = AsyncState.Failure(err))
+      case Right(value) => IO(state.value = AsyncState.Success(value))
+    }
+    SyncIO(state.value = AsyncState.Pending)
+      .flatMap(_ => start)
+      .unsafeRunSync()
+  }
+
+
+  override private[binding] def value: AsyncState[T] = state.value
+
+  override private[binding] def removeChangedListener(listener: Binding.ChangedListener[AsyncState[T]]): Unit = state.removeChangedListener(listener)
+
+  override private[binding] def addChangedListener(listener: Binding.ChangedListener[AsyncState[T]]): Unit = state.addChangedListener(listener)
+}

--- a/AsyncBinding/src/main/scala/com/thoughtworks/binding/async/AsyncState.scala
+++ b/AsyncBinding/src/main/scala/com/thoughtworks/binding/async/AsyncState.scala
@@ -1,0 +1,26 @@
+package com.thoughtworks.binding.async
+
+sealed trait AsyncState[+T] {
+  def get: Option[T]
+}
+
+object AsyncState {
+
+  //TODO naming
+  case object NotStarted extends AsyncState[Nothing] {
+    override def get: Option[Nothing] = None
+  }
+
+  case object Pending extends AsyncState[Nothing] {
+    override def get: Option[Nothing] = None
+  }
+
+  case class Success[T](value: T) extends AsyncState[T] {
+    override val get: Option[T] = Some(value)
+  }
+
+  case class Failure(error: Throwable) extends AsyncState[Nothing] {
+    override def get: Option[Nothing] = None
+  }
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,8 @@ lazy val Binding = crossProject.crossType(CrossType.Pure)
 
 lazy val FutureBinding = crossProject.crossType(CrossType.Pure).dependsOn(Binding)
 
+lazy val AsyncBinding = crossProject.crossType(CrossType.Pure).dependsOn(Binding)
+
 lazy val dom = project.dependsOn(BindingJS).dependsOn(XmlExtractorJS)
 
 lazy val Route = project.dependsOn(BindingJS)
@@ -17,6 +19,10 @@ lazy val BindingJVM = Binding.jvm.addSbtFiles(file("../build.sbt.shared"))
 lazy val FutureBindingJS = FutureBinding.js.addSbtFiles(file("../build.sbt.shared"))
 
 lazy val FutureBindingJVM = FutureBinding.jvm.addSbtFiles(file("../build.sbt.shared"))
+
+lazy val AsyncBindingJS = AsyncBinding.js.addSbtFiles(file("../build.sbt.shared"))
+
+lazy val AsyncBindingJVM = AsyncBinding.jvm.addSbtFiles(file("../build.sbt.shared"))
 
 lazy val XmlExtractor = crossProject.crossType(CrossType.Pure)
 


### PR DESCRIPTION
This is a base for discussion rather than something to be merged. 

This simple implementation introduce support for any `F[_]` that has instance of `Effect`. This implementation has couple of problems

1. We already have `FutureBinding` which is different in two things 
    1. `Option[Try[A]` vs introduced here `AsyncState[A]` - I believe `AsyncState` could be added to `FutureBinding` but it requires API polishing, I'm not sure how it should look like in the end.
    1. not being able to refresh/recompute the value - this could be solved by taking a future by name in `FutureBinding`.
2. `cats-effect` is not available for scala 2.10

So if anyone has some opinion/ideas about the direction this should take, please let me know. 
If you feel that no improvements in this area are needed, feel free to close a PR. I have this code in my app anyway and it's not a problem if it stays that way.

