### PR TITLE
[WIP] Dom component

### DIFF
--- a/dom/src/test/scala/com/thoughtworks/binding/DomComponentTest.scala
+++ b/dom/src/test/scala/com/thoughtworks/binding/DomComponentTest.scala
@@ -1,6 +1,6 @@
 package com.thoughtworks.binding
 
-import com.thoughtworks.binding.Binding.BindingSeq
+import com.thoughtworks.binding.Binding.{BindingSeq, Constant}
 import com.thoughtworks.binding.dom.Runtime.TagsAndTags2
 import org.scalajs.dom.Node
 import org.scalatest.{FreeSpec, Matchers}
@@ -80,6 +80,12 @@ class DomComponentTest extends FreeSpec with Matchers {
     implicit final class UserTags(x: TagsAndTags2.type) {
       @dom
       def dialog(): Binding[Div] = <div class="dialog"/>
+
+      @dom
+      def dialog(id: Binding[String]): Binding[Div] = <div class="dialog" id={id.bind}/>
+
+      @dom
+      def dialog(children: BindingSeq[Node], id: Binding[String] = Constant("dialog")): Binding[Div] = <div class="rich-dialog" id={id.bind}>{children}</div>
     }
 
     "can be used as child" in {
@@ -102,6 +108,27 @@ class DomComponentTest extends FreeSpec with Matchers {
       html.watch()
 
       assert(html.get.outerHTML == """<div><div class="dialog"/><div class="dialog"/></div>""")
+    }
+
+    "should support attributes" in {
+      @dom val html = <dialog id="123"/>
+      html.watch()
+
+      assert(html.get.outerHTML == """<div id="123" class="dialog"/>""")
+    }
+
+    "should support overloading" in {
+      @dom val html = <dialog id="123"><div/></dialog>
+      html.watch()
+
+      assert(html.get.outerHTML == """<div id="123" class="rich-dialog"><div/></div>""")
+    }
+
+    "should support defaults" in {
+      @dom val html = <dialog><div/></dialog>
+      html.watch()
+
+      assert(html.get.outerHTML == """<div id="dialog" class="rich-dialog"><div/></div>""")
     }
   }
 }

--- a/dom/src/test/scala/com/thoughtworks/binding/DomComponentTest.scala
+++ b/dom/src/test/scala/com/thoughtworks/binding/DomComponentTest.scala
@@ -1,0 +1,107 @@
+package com.thoughtworks.binding
+
+import com.thoughtworks.binding.Binding.BindingSeq
+import com.thoughtworks.binding.dom.Runtime.TagsAndTags2
+import org.scalajs.dom.Node
+import org.scalatest.{FreeSpec, Matchers}
+import org.scalajs.dom.html.Div
+
+/**
+  * @author Leonid Turnaev &lt;lmars@mail.ru&gt;
+  */
+class DomComponentTest extends FreeSpec with Matchers {
+
+  "without children" - {
+    implicit final class UserTags(x: TagsAndTags2.type) {
+      @dom
+      def dialog(): Binding[Div] = <div class="dialog"/>
+    }
+
+    "can be self closed tag" in {
+      @dom val html = <div><dialog/></div>
+      html.watch()
+
+      assert(html.get.outerHTML == """<div><div class="dialog"/></div>""")
+    }
+
+    "can be empty tag" in {
+      @dom val html = <div><dialog></dialog></div>
+      html.watch()
+
+      assert(html.get.outerHTML == """<div><div class="dialog"/></div>""")
+    }
+
+    "should not compile with children" in {
+      assertDoesNotCompile("@dom val html = <div><dialog><div/></dialog></div>")
+    }
+
+    "also should not compile with child text node" in {
+      assertDoesNotCompile("@dom val html = <div><dialog>    </dialog></div>")
+    }
+  }
+
+  "with children" - {
+    implicit final class UserTags(x: TagsAndTags2.type) {
+      @dom
+      def dialog(children: BindingSeq[Node]): Binding[Div] = <div class="dialog">{children}</div>
+    }
+
+    "can have single child" in {
+      @dom val html = <div><dialog><div/></dialog></div>
+      html.watch()
+
+      assert(html.get.outerHTML == """<div><div class="dialog"><div/></div></div>""")
+    }
+
+    "can have more than one child" in {
+      @dom val html = <div><dialog><div/><button><i>OK</i></button></dialog></div>
+      html.watch()
+
+      assert(html.get.outerHTML == """<div><div class="dialog"><div/><button><i>OK</i></button></div></div>""")
+    }
+
+    "can have child text node" in {
+      @dom val html = <div><dialog>    </dialog></div>
+      html.watch()
+
+      assert(html.get.outerHTML == """<div><div class="dialog">    </div></div>""")
+    }
+
+    "should not compile as self closed tag" in {
+      assertDoesNotCompile("@dom val html = <div><dialog/></div>")
+    }
+
+    "should not compile as empty tag" in {
+      assertDoesNotCompile("@dom val html = <div><dialog></dialog></div>")
+    }
+  }
+
+  "dom component" - {
+    implicit final class UserTags(x: TagsAndTags2.type) {
+      @dom
+      def dialog(): Binding[Div] = <div class="dialog"/>
+    }
+
+    "can be used as child" in {
+      @dom val html = <div><dialog/></div>
+      html.watch()
+
+      assert(html.get.outerHTML == """<div><div class="dialog"/></div>""")
+    }
+
+    "can be used standalone" in {
+      @dom val html = <dialog/>
+      html.watch()
+
+      assert(html.get.outerHTML == """<div class="dialog"/>""")
+    }
+
+    "can be used in sequence" in {
+      @dom val components = <dialog/><dialog/>
+      @dom val html = <div>{components.bind}</div>
+      html.watch()
+
+      assert(html.get.outerHTML == """<div><div class="dialog"/><div class="dialog"/></div>""")
+    }
+  }
+}


### PR DESCRIPTION
It's early early early preview of dom component feature (please, see discussion in https://github.com/ThoughtWorksInc/Binding.scala/issues/128). 

The main idea is introducing special syntax to extract peace of a `@dom` powered code as the separate reusable elements. I'm called it - "dom components".

```scala
object Dialog {
  @dom
  def apply(id: Binding[String], children: BindingSeq[Node]): Binding[Div] = <div id={id.bind} class="dialog">{children}</div>
}

implicit final class DialogTags(x: TagsAndTags2.type) {
  @domcomponent
  val dialog = Dialog
}
```

Which can be used in @dom functions:

```scala
@dom val html = <dialog id="123"><button><i>OK</i></button></dialog>
```

It generates such DOM tree:
```html
<div id="123" class="dialog"><button><i>OK</i></button></div>
```

:exclamation:Hardcode:exclamation: - only `dialog` tag is considered as a dom component in this preview

/cc @sadhen, @ccamel, @jfilali, @skaz1970, @maxkorolev, @csoren