### PR TITLE
Revert 252da6101fab2fbb3e54e40ead084029e5e18963 in case of breaking source code backward-compatibility

### DIFF
--- a/Binding/src/main/scala/com/thoughtworks/binding/Binding.scala
+++ b/Binding/src/main/scala/com/thoughtworks/binding/Binding.scala
@@ -363,7 +363,7 @@ object Binding extends MonadicFactory.WithTypeClass[Monad, Binding] {
     }
 
     @inline
-    override def value: B = {
+    override protected def value: B = {
       cache
     }
 
@@ -442,7 +442,7 @@ object Binding extends MonadicFactory.WithTypeClass[Monad, Binding] {
       cache = f(upstream.value)
     }
 
-    override def value: B = {
+    override protected def value: B = {
       @tailrec
       @inline
       def tailrecGetValue(binding: Binding[B]): B = {
@@ -615,7 +615,7 @@ object Binding extends MonadicFactory.WithTypeClass[Monad, Binding] {
     override protected def addPatchedListener(listener: PatchedListener[Nothing]): Unit = {}
 
     @inline
-    override def value = Nil
+    override protected def value = Nil
   }
 
   private[Binding] abstract class ValueProxy[B] extends Seq[B] with HasCache[Binding[B]] {
@@ -726,7 +726,7 @@ object Binding extends MonadicFactory.WithTypeClass[Monad, Binding] {
       }
 
       @inline
-      override def value = new FlatProxy(cacheData)
+      override protected def value = new FlatProxy(cacheData)
 
       @inline
       private def flatIndex(oldCache: Cache, upstreamBegin: Int, upstreamEnd: Int): Int = {
@@ -848,7 +848,7 @@ object Binding extends MonadicFactory.WithTypeClass[Monad, Binding] {
         } yield f(a))(collection.breakOut)
       }
 
-      override def value: Seq[B] = {
+      override protected def value: Seq[B] = {
         val cacheData0 = cacheData
         new ValueProxy[B] {
           var cacheData = cacheData0
@@ -918,7 +918,7 @@ object Binding extends MonadicFactory.WithTypeClass[Monad, Binding] {
       private val publisher = new SafeBuffer[ChangedListener[Int]]
 
       @inline
-      override def value: Int = bindingSeq.value.length
+      override protected def value: Int = bindingSeq.value.length
 
       @inline
       override protected def removeChangedListener(listener: ChangedListener[Int]): Unit = {
@@ -961,7 +961,7 @@ object Binding extends MonadicFactory.WithTypeClass[Monad, Binding] {
       private val publisher = new SafeBuffer[ChangedListener[Seq[Element]]]
 
       @inline
-      override def value: Seq[Element] = upstream.value
+      override protected def value: Seq[Element] = upstream.value
 
       @inline
       override protected def removeChangedListener(listener: ChangedListener[Seq[Element]]): Unit = {
@@ -1016,18 +1016,13 @@ object Binding extends MonadicFactory.WithTypeClass[Monad, Binding] {
       removePatchedListener(Binding.DummyPatchedListener)
     }
 
-    /**
-      * Returns the current value of this [[BindingSeq]].
-      *
-      * @note This method must not be invoked inside a `@dom` method body or a `Binding { ... }` block..
-      */
-    def value: Seq[A]
+    /** Returns the current value of this [[BindingSeq]]. */
+    protected def value: Seq[A]
 
     /** Returns the current value of this [[BindingSeq]].
       *
       * @note This method is used for internal testing purpose only.
       */
-    @deprecated(message = "Use [[value]] instead", since = "11.0.0")
     private[binding] def get: Seq[A] = value
 
     protected def removePatchedListener(listener: PatchedListener[A]): Unit
@@ -1377,7 +1372,7 @@ object Binding extends MonadicFactory.WithTypeClass[Monad, Binding] {
     override def length: Constant[Int] = Constant(1)
 
     @inline
-    override def value = SingleSeq(upstream.value)
+    override protected def value = SingleSeq(upstream.value)
 
     @inline
     override protected def removePatchedListener(listener: PatchedListener[A]): Unit = {
@@ -1427,7 +1422,7 @@ object Binding extends MonadicFactory.WithTypeClass[Monad, Binding] {
     }
 
     @inline
-    override def value: Unit = ()
+    override protected def value: Unit = ()
 
   }
 
@@ -1520,7 +1515,6 @@ trait Binding[+A] {
     */
   final def bind: A = macro Binding.Macros.bind
 
-  @deprecated(message = "Use [[value]] instead", since = "11.0.0")
   private[binding] def get: A = value
 
   /**
@@ -1528,7 +1522,7 @@ trait Binding[+A] {
     *
     * @note This method must not be invoked inside a `@dom` method body or a `Binding { ... }` block..
     */
-  def value: A
+  protected def value: A
 
   protected def removeChangedListener(listener: Binding.ChangedListener[A]): Unit
 

--- a/Binding/src/test/scala/com/thoughtworks/binding/BindingTest.scala
+++ b/Binding/src/test/scala/com/thoughtworks/binding/BindingTest.scala
@@ -53,9 +53,9 @@ final class BindingTest extends FreeSpec with Matchers {
     }
     hello.watch()
 
-    assert(hello.value == "Hello, World!")
+    assert(hello.get == "Hello, World!")
     target.value = "Each"
-    assert(hello.value == "Hello, Each!")
+    assert(hello.get == "Hello, Each!")
   }
 
   "TripleBinding" in {
@@ -64,10 +64,10 @@ final class BindingTest extends FreeSpec with Matchers {
       input.bind + input.bind + input.bind
     }
     output.watch()
-    assert(output.value == 0)
+    assert(output.get == 0)
     for (i <- 0 until 10) {
       input.value = i
-      assert(output.value == i * 3)
+      assert(output.get == i * 3)
     }
   }
 
@@ -89,7 +89,7 @@ final class BindingTest extends FreeSpec with Matchers {
 
     var resultChanged = 0
 
-    assert(expr1.value == 0)
+    assert(expr1.get == 0)
 
     addChangedListener(expr1, new ChangedListener[Any] {
       override def changed(event: ChangedEvent[Any]): Unit = {
@@ -98,12 +98,12 @@ final class BindingTest extends FreeSpec with Matchers {
     })
 
     assert(resultChanged == 0)
-    assert(expr1.value == 32100)
+    assert(expr1.get == 32100)
 
     expr3.value = 4000
 
     assert(resultChanged == 1)
-    assert(expr1.value == 34100)
+    assert(expr1.get == 34100)
 
   }
 
@@ -122,10 +122,10 @@ final class BindingTest extends FreeSpec with Matchers {
         resultChanged += 1
       }
     })
-    assert(result.value == 0.5)
+    assert(result.get == 0.5)
     assert(resultChanged == 0)
     source.value = 4.0
-    assert(result.value == 0.25)
+    assert(result.get == 0.25)
     assert(resultChanged == 1)
   }
 
@@ -218,7 +218,7 @@ final class BindingTest extends FreeSpec with Matchers {
         assert(event.that == Seq("ForYield 0/3", "ForYield 1/3", "ForYield 2/3"))
     }
     assert(
-      mapped.value == Seq(
+      mapped.get == Seq(
         "ForYield 0/2",
         "ForYield 1/2",
         "ForYield 0/3",
@@ -234,7 +234,7 @@ final class BindingTest extends FreeSpec with Matchers {
       ))
     prefix.value = "3"
     assert(sourceEvents.length == 4)
-    assert(mapped.value == Seq("3 0/2", "3 1/2", "3 0/4", "3 1/4", "3 2/4", "3 3/4"))
+    assert(mapped.get == Seq("3 0/2", "3 1/2", "3 0/4", "3 1/4", "3 2/4", "3 3/4"))
 
     removePatchedListener(mapped, mappedEvents.listener)
     removePatchedListener(source, sourceEvents.listener)
@@ -595,7 +595,7 @@ final class BindingTest extends FreeSpec with Matchers {
       val myVars = Vars(1, 2, 100, 3)
       val filtered = myVars.withFilter(_ < 10).map(x => x)
       filtered.watch()
-      assert(filtered.value == Seq(1, 2, 3))
+      assert(filtered.get == Seq(1, 2, 3))
     }
   }
 
@@ -620,21 +620,21 @@ final class BindingTest extends FreeSpec with Matchers {
     c.watch()
 
     var result: (Int, Int) = null
-    assert((3, 1) == ((c.value, count)))
+    assert((3, 1) == ((c.get, count)))
 
     a.value = 4
-    assert((6, 2) == ((c.value, count)))
+    assert((6, 2) == ((c.get, count)))
 
     b.value = 3
-    assert((7, 3) == ((c.value, count)))
+    assert((7, 3) == ((c.get, count)))
 
     (0 to 100).foreach { i =>
       a.value = i
     }
-    assert((103, 104) == ((c.value, count)))
+    assert((103, 104) == ((c.get, count)))
 
     b.value = 4
-    assert((104, 105) == ((c.value, count)))
+    assert((104, 105) == ((c.get, count)))
   }
 
   "multi to one dependencies" in {
@@ -658,15 +658,15 @@ final class BindingTest extends FreeSpec with Matchers {
     }
     Binding.BindingInstances.ap _
     aPlusOneTimesBPlusOn.watch()
-    aPlusOneTimesBPlusOn.value should be((100 + 1) * (200 + 1))
+    aPlusOneTimesBPlusOn.get should be((100 + 1) * (200 + 1))
     aFlushCount should be(1)
     bFlushCount should be(1)
     a.value = 500
-    aPlusOneTimesBPlusOn.value should be((500 + 1) * (200 + 1))
+    aPlusOneTimesBPlusOn.get should be((500 + 1) * (200 + 1))
     aFlushCount should be(2)
     bFlushCount should be(2)
     b.value = 600
-    aPlusOneTimesBPlusOn.value should be((500 + 1) * (600 + 1))
+    aPlusOneTimesBPlusOn.get should be((500 + 1) * (600 + 1))
     aFlushCount should be(2)
     bFlushCount should be(3)
 
@@ -680,7 +680,7 @@ final class BindingTest extends FreeSpec with Matchers {
         if myVar < 10
       } yield myVar
       filtered.watch()
-      assert(filtered.value == Seq(1, 2, 3))
+      assert(filtered.get == Seq(1, 2, 3))
     }
     domMethod()
   }
@@ -688,7 +688,7 @@ final class BindingTest extends FreeSpec with Matchers {
   "flatMap" in {
     val flatMapped = Constants(Constants(1, 2), Constants(), Constants(3)).flatMap(identity)
     flatMapped.watch()
-    flatMapped.value should be(Seq(1, 2, 3))
+    flatMapped.get should be(Seq(1, 2, 3))
   }
 
   "foreach" in {

--- a/Binding/src/test/scala/com/thoughtworks/binding/regression/InsertThenClear.scala
+++ b/Binding/src/test/scala/com/thoughtworks/binding/regression/InsertThenClear.scala
@@ -39,13 +39,13 @@ final class InsertThenClear extends FreeSpec with Matchers {
 
     val mapped = items.map(-_)
     mapped.watch()
-    assert(mapped.value == Seq(-1, -2, -3, -4, -5, -6, -7, -8, -9, -10))
+    assert(mapped.get == Seq(-1, -2, -3, -4, -5, -6, -7, -8, -9, -10))
 
     items.value.insertAll(3, 100 to 103)
-    assert(mapped.value == Seq(-1, -2, -3, -100, -101, -102, -103, -4, -5, -6, -7, -8, -9, -10))
+    assert(mapped.get == Seq(-1, -2, -3, -100, -101, -102, -103, -4, -5, -6, -7, -8, -9, -10))
 
     items.value.clear()
-    assert(mapped.value == Seq.empty)
+    assert(mapped.get == Seq.empty)
   }
 }
 

--- a/Binding/src/test/scala/com/thoughtworks/binding/regression/Issue56.scala
+++ b/Binding/src/test/scala/com/thoughtworks/binding/regression/Issue56.scala
@@ -28,7 +28,7 @@ final class Issue56 extends FreeSpec with Matchers {
     result.watch()
     dataSource.value = 300
     isEnabled.value = true
-    result.value should be(301)
+    result.get should be(301)
   }
 
 }

--- a/Binding/src/test/scala/com/thoughtworks/binding/regression/Zhihu50863924.scala
+++ b/Binding/src/test/scala/com/thoughtworks/binding/regression/Zhihu50863924.scala
@@ -56,9 +56,9 @@ final class Zhihu50863924 extends FreeSpec with Matchers {
     }
 
     render.watch()
-    assert(render.value == Left("None here!"))
+    assert(render.get == Left("None here!"))
     value.value = Some("Changed")
-    assert(render.value == Right("Changed"))
+    assert(render.get == Right("Changed"))
     assert(renderCount0 == 1)
     assert(renderCount1 == 1)
   }

--- a/JsPromiseBinding/src/main/scala/com/thoughtworks/binding/JsPromiseBinding.scala
+++ b/JsPromiseBinding/src/main/scala/com/thoughtworks/binding/JsPromiseBinding.scala
@@ -119,7 +119,7 @@ final class JsPromiseBinding[A](thenable: Thenable[A]) extends Binding[Option[Ei
 
   private val publisher = new SafeBuffer[ChangedListener[Option[Either[Any, A]]]]
 
-  override def value = cache
+  override protected def value = cache
 
   override protected def removeChangedListener(listener: ChangedListener[Option[Either[Any, A]]]): Unit = {
     publisher -= listener

--- a/dom/src/test/scala/com/thoughtworks/binding/Issue113.scala
+++ b/dom/src/test/scala/com/thoughtworks/binding/Issue113.scala
@@ -7,7 +7,7 @@ class Issue113 extends FreeSpec with Matchers {
   "name clash should be avoided" in {
     val dialog = dialogUI("id")
     dialog.watch()
-    dialog.value.outerHTML should be ("""<aside id="id">
+    dialog.get.outerHTML should be ("""<aside id="id">
     <div>
       <fieldset>
       </fieldset>

--- a/dom/src/test/scala/com/thoughtworks/binding/Issue118.scala
+++ b/dom/src/test/scala/com/thoughtworks/binding/Issue118.scala
@@ -8,8 +8,8 @@ class Issue118 extends FreeSpec with Matchers {
   "XHTML boolean attributes should compile" in {
     @dom val elementWithBooleanAttributes = <textarea hidden="hidden" draggable="true" readOnly="readOnly"></textarea>
     elementWithBooleanAttributes.watch()
-    elementWithBooleanAttributes.value.getAttribute("draggable") should be("true")
-    elementWithBooleanAttributes.value.getAttribute("hidden") should be("hidden")
-    elementWithBooleanAttributes.value.getAttribute("readOnly") should be("readOnly")
+    elementWithBooleanAttributes.get.getAttribute("draggable") should be("true")
+    elementWithBooleanAttributes.get.getAttribute("hidden") should be("hidden")
+    elementWithBooleanAttributes.get.getAttribute("readOnly") should be("readOnly")
   }
 }

--- a/dom/src/test/scala/com/thoughtworks/binding/Issue21.scala
+++ b/dom/src/test/scala/com/thoughtworks/binding/Issue21.scala
@@ -10,6 +10,6 @@ class Issue21 extends FreeSpec with Matchers {
   "dashed-id should compile" in {
     @dom def invalidId: Binding[html.Div] = <div id="dashed-id" class={ s"${`dashed-id`.tagName}-1" }></div>
     invalidId.watch()
-    invalidId.value.className should be("DIV-1")
+    invalidId.get.className should be("DIV-1")
   }
 }

--- a/dom/src/test/scala/com/thoughtworks/binding/domTest.scala
+++ b/dom/src/test/scala/com/thoughtworks/binding/domTest.scala
@@ -43,65 +43,65 @@ final class domTest extends FreeSpec with Matchers {
   }
 
   "PrivateEmptyElement" in {
-    assert(privateMonadicBr.value.outerHTML == "<br/>")
+    assert(privateMonadicBr.get.outerHTML == "<br/>")
   }
 
   "EmptyElement" in {
     @dom val monadicBr: Binding[BR] = <br/>
-    assert(monadicBr.value.outerHTML == "<br/>")
+    assert(monadicBr.get.outerHTML == "<br/>")
   }
 
   "TextElement" in {
     @dom val monadicDiv: Binding[Div] = <div>text</div>
     monadicDiv.watch()
-    assert(monadicDiv.value.outerHTML == "<div>text</div>")
+    assert(monadicDiv.get.outerHTML == "<div>text</div>")
   }
 
   "TextInterpolationElement" in {
     @dom val monadicDiv: Binding[Div] = <div>{"text"}</div>
     monadicDiv.watch()
-    assert(monadicDiv.value.outerHTML == "<div>text</div>")
+    assert(monadicDiv.get.outerHTML == "<div>text</div>")
   }
 
   "NestedElement" in {
     @dom val monadicDiv: Binding[Div] = <div> <span> text </span> </div>
     monadicDiv.watch()
-    assert(monadicDiv.value.outerHTML == "<div> <span> text </span> </div>")
+    assert(monadicDiv.get.outerHTML == "<div> <span> text </span> </div>")
   }
 
   "ChangedElementText" in {
     val v0 = Var("original text")
     @dom val monadicDiv: Binding[Div] = <div> <span> {v0.bind} </span> </div>
     monadicDiv.watch()
-    assert(monadicDiv.value.outerHTML == "<div> <span> original text </span> </div>")
+    assert(monadicDiv.get.outerHTML == "<div> <span> original text </span> </div>")
     v0.value = "changed"
-    assert(monadicDiv.value.outerHTML == "<div> <span> changed </span> </div>")
+    assert(monadicDiv.get.outerHTML == "<div> <span> changed </span> </div>")
   }
 
   "ForYield" in {
     val v0 = Vars("original text 0","original text 1")
     @dom val monadicDiv: Binding[Div] = <div> <span> { for (s <- v0) yield <b>{s}</b> } </span> </div>
     monadicDiv.watch()
-    val div = monadicDiv.value
+    val div = monadicDiv.get
 
-    assert(monadicDiv.value.outerHTML == "<div> <span> <b>original text 0</b><b>original text 1</b> </span> </div>")
+    assert(monadicDiv.get.outerHTML == "<div> <span> <b>original text 0</b><b>original text 1</b> </span> </div>")
 
     v0.value.prepend("prepended")
-    assert(div eq monadicDiv.value)
-    assert(monadicDiv.value.outerHTML == "<div> <span> <b>prepended</b><b>original text 0</b><b>original text 1</b> </span> </div>")
+    assert(div eq monadicDiv.get)
+    assert(monadicDiv.get.outerHTML == "<div> <span> <b>prepended</b><b>original text 0</b><b>original text 1</b> </span> </div>")
 
     v0.value.remove(1)
-    assert(div eq monadicDiv.value)
-    assert(monadicDiv.value.outerHTML == "<div> <span> <b>prepended</b><b>original text 1</b> </span> </div>")
+    assert(div eq monadicDiv.get)
+    assert(monadicDiv.get.outerHTML == "<div> <span> <b>prepended</b><b>original text 1</b> </span> </div>")
   }
 
   "Attribute" in {
     val id = Var("oldId")
     @dom val hr = <hr id={id.bind}/>
     hr.watch()
-    assert(hr.value.outerHTML == """<hr id="oldId"/>""")
+    assert(hr.get.outerHTML == """<hr id="oldId"/>""")
     id.value = "newId"
-    assert(hr.value.outerHTML == """<hr id="newId"/>""")
+    assert(hr.get.outerHTML == """<hr id="newId"/>""")
   }
 
   "ForYieldIf" in {
@@ -145,9 +145,9 @@ final class domTest extends FreeSpec with Matchers {
       <table title="My Tooltip" className="my-table"><thead><tr><td>First Name</td><td>Second Name</td><td>Age</td></tr></thead>{tbodyBinding.bind}</table>
     }
     tableBinding.watch()
-    assert(tableBinding.value.outerHTML == """<table class="my-table" title="My Tooltip"><thead><tr><td>First Name</td><td>Second Name</td><td>Age</td></tr></thead><tbody><tr><td>Steve</td><td>Jobs</td><td>10</td></tr><tr><td>Tim</td><td>Cook</td><td>12</td></tr><tr><td>Jeff</td><td>Lauren</td><td>13</td></tr></tbody></table>""")
+    assert(tableBinding.get.outerHTML == """<table class="my-table" title="My Tooltip"><thead><tr><td>First Name</td><td>Second Name</td><td>Age</td></tr></thead><tbody><tr><td>Steve</td><td>Jobs</td><td>10</td></tr><tr><td>Tim</td><td>Cook</td><td>12</td></tr><tr><td>Jeff</td><td>Lauren</td><td>13</td></tr></tbody></table>""")
     filterPattern.value = "o"
-    assert(tableBinding.value.outerHTML == """<table class="my-table" title="My Tooltip"><thead><tr><td>First Name</td><td>Second Name</td><td>Age</td></tr></thead><tbody><tr><td>Steve</td><td>Jobs</td><td>10</td></tr><tr><td>Tim</td><td>Cook</td><td>12</td></tr></tbody></table>""")
+    assert(tableBinding.get.outerHTML == """<table class="my-table" title="My Tooltip"><thead><tr><td>First Name</td><td>Second Name</td><td>Age</td></tr></thead><tbody><tr><td>Steve</td><td>Jobs</td><td>10</td></tr><tr><td>Tim</td><td>Cook</td><td>12</td></tr></tbody></table>""")
   }
 
   "NodeSeq" in {
@@ -234,7 +234,7 @@ final class domTest extends FreeSpec with Matchers {
         if myVar < 10
       } yield myVar
       filtered.watch()
-      assert(filtered.value == Seq(1, 2, 3))
+      assert(filtered.get == Seq(1, 2, 3))
     }
     domMethod()
   }
@@ -287,10 +287,10 @@ final class domTest extends FreeSpec with Matchers {
     val div = document.createElement("div")
     dom.render(div, input)
     assert(v.value == "Initial value")
-    assert(input.value.value(0).asInstanceOf[Input].value == "Initial value")
+    assert(input.get.get(0).asInstanceOf[Input].value == "Initial value")
     div.firstChild.asInstanceOf[Input].onclick(null)
     assert(v.value == "INPUT and Label Text")
-    assert(input.value.value(0).asInstanceOf[Input].value == "INPUT and Label Text")
+    assert(input.get.get(0).asInstanceOf[Input].value == "INPUT and Label Text")
   }
 
   "id in Binding" in {
@@ -303,10 +303,10 @@ final class domTest extends FreeSpec with Matchers {
     val div = document.createElement("div")
     dom.render(div, input)
     assert(v.value == "Initial value")
-    assert(input.value.value == "Initial value")
+    assert(input.get.value == "Initial value")
     div.firstChild.asInstanceOf[Input].onclick(null)
     assert(v.value == "INPUT")
-    assert(input.value.value == "INPUT")
+    assert(input.get.value == "INPUT")
   }
 
   "Seq in DOM" in {
@@ -331,9 +331,9 @@ final class domTest extends FreeSpec with Matchers {
     @dom val div = <div>{text.bind}</div>
     div.watch()
 
-    assert(div.value.outerHTML == "<div><b>warning</b></div>")
+    assert(div.get.outerHTML == "<div><b>warning</b></div>")
     warning.value = false
-    assert(div.value.outerHTML == "<div/>")
+    assert(div.get.outerHTML == "<div/>")
   }
 
   "OptionMonadicExpression" in {
@@ -344,22 +344,22 @@ final class domTest extends FreeSpec with Matchers {
     @dom val div = <div>{text.bind}</div>
     div.watch()
 
-    assert(div.value.outerHTML == "<div><span>firstName</span></div>")
+    assert(div.get.outerHTML == "<div><span>firstName</span></div>")
     firstName.value = None
-    assert(div.value.outerHTML == "<div/>")
+    assert(div.get.outerHTML == "<div/>")
   }
 
   "OptionalAttribute" in {
     val id = Var[scala.Option[String]](Some("oldId"))
     @dom val hr = <hr option:id={id.bind}/>
     hr.watch()
-    assert(hr.value.outerHTML == """<hr id="oldId"/>""")
+    assert(hr.get.outerHTML == """<hr id="oldId"/>""")
     id.value = Some("newId")
-    assert(hr.value.outerHTML == """<hr id="newId"/>""")
+    assert(hr.get.outerHTML == """<hr id="newId"/>""")
     id.value = None
-    assert(hr.value.outerHTML == "<hr/>")
+    assert(hr.get.outerHTML == "<hr/>")
     id.value = Some("createdId")
-    assert(hr.value.outerHTML == """<hr id="createdId"/>""")
+    assert(hr.get.outerHTML == """<hr id="createdId"/>""")
   }
 
 
@@ -409,10 +409,10 @@ final class domTest extends FreeSpec with Matchers {
     val div = document.createElement("div")
     dom.render(div, input)
     assert(v.value == "Initial value")
-    assert(input.value.value(0).asInstanceOf[Input].value == "Initial value")
+    assert(input.get.get(0).asInstanceOf[Input].value == "Initial value")
     div.firstChild.asInstanceOf[Input].onclick(null)
     assert(v.value == "INPUT and Label Text")
-    assert(input.value.value(0).asInstanceOf[Input].value == "INPUT and Label Text")
+    assert(input.get.get(0).asInstanceOf[Input].value == "INPUT and Label Text")
   }
 
   "local-id in Binding" in {
@@ -425,16 +425,16 @@ final class domTest extends FreeSpec with Matchers {
     val div = document.createElement("div")
     dom.render(div, input)
     assert(v.value == "Initial value")
-    assert(input.value.value == "Initial value")
+    assert(input.get.value == "Initial value")
     div.firstChild.asInstanceOf[Input].onclick(null)
     assert(v.value == "INPUT")
-    assert(input.value.value == "INPUT")
+    assert(input.get.value == "INPUT")
   }
 
   "dashed-local-id should compile" in {
     @dom def div = <div local-id="dashed-id" class={ s"${`dashed-id`.tagName}-1" }></div>
     div.watch()
-    assert(div.value.className == "DIV-1")
+    assert(div.get.className == "DIV-1")
   }
 
   "CustomTag" in {

--- a/fxml/.js/src/test/scala/com/thoughtworks/binding/DateSpec.scala
+++ b/fxml/.js/src/test/scala/com/thoughtworks/binding/DateSpec.scala
@@ -14,7 +14,7 @@ final class DateSpec extends FreeSpec with Matchers with Inside {
       </Date>
     }
     date.watch()
-    date.value.getDate should be(2)
-    date.value.getMilliseconds should be(42)
+    date.get.getDate should be(2)
+    date.get.getMilliseconds should be(42)
   }
 }

--- a/fxml/.jvm/src/test/scala/com/thoughtworks/binding/fxmlTest.scala
+++ b/fxml/.jvm/src/test/scala/com/thoughtworks/binding/fxmlTest.scala
@@ -25,8 +25,8 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
       </Scene>
     }
     scene.watch()
-    scene.value should be(a[javafx.scene.Scene])
-    scene.value.getRoot should be(a[javafx.scene.control.Button])
+    scene.get should be(a[javafx.scene.Scene])
+    scene.get.getRoot should be(a[javafx.scene.control.Button])
   }
 
   "root property in Scene" in {
@@ -40,8 +40,8 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
       </Scene>
     }
     scene.watch()
-    scene.value should be(a[javafx.scene.Scene])
-    scene.value.getRoot should be(a[javafx.scene.control.Button])
+    scene.get should be(a[javafx.scene.Scene])
+    scene.get.getRoot should be(a[javafx.scene.control.Button])
   }
 
   "repeated property in Scene" in {
@@ -59,9 +59,9 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
       </Scene>
     }
     scene.watch()
-    scene.value should be(a[javafx.scene.Scene])
-    scene.value.getRoot should be(a[javafx.scene.control.Button])
-    inside(scene.value.getStylesheets.asScala) {
+    scene.get should be(a[javafx.scene.Scene])
+    scene.get.getRoot should be(a[javafx.scene.control.Button])
+    inside(scene.get.getStylesheets.asScala) {
       case Seq("a", s2, "c", "d", "e") =>
         s2 shouldNot be(empty)
     }
@@ -73,7 +73,7 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
       <StringMap foo="123" bar=""/>
     }
     hashMap.watch()
-    hashMap.value.asScala should be(Map("foo" -> "123", "bar" -> ""))
+    hashMap.get.asScala should be(Map("foo" -> "123", "bar" -> ""))
   }
 
   "Nested builders" in {
@@ -93,9 +93,9 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
       </Scene>
     }
     scene.watch()
-    scene.value should be(a[javafx.scene.Scene])
-    scene.value.getRoot should be(a[javafx.scene.control.Button])
-    scene.value.getFill should be(javafx.scene.paint.Color.RED)
+    scene.get should be(a[javafx.scene.Scene])
+    scene.get.getRoot should be(a[javafx.scene.control.Button])
+    scene.get.getFill should be(javafx.scene.paint.Color.RED)
   }
 
   "fx:factory" in {
@@ -109,7 +109,7 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
     }
     observableArrayList.watch()
     import scala.collection.JavaConverters._
-    observableArrayList.value.asScala should be(Seq("A", "B", ""))
+    observableArrayList.get.asScala should be(Seq("A", "B", ""))
   }
 
   "Reference outer element by fx:id" in {
@@ -125,9 +125,9 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
     inside(pair) {
       case (button, button2) =>
         button.watch()
-        button.value.getText shouldNot be("")
+        button.get.getText shouldNot be("")
         button2.watch()
-        button2.value.getText shouldNot be("")
+        button2.get.getText shouldNot be("")
     }
 
   }
@@ -145,7 +145,7 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
     }
 
     buttons.watch()
-    inside(buttons.value) {
+    inside(buttons.get) {
       case Seq(button1, button2) =>
         button1.getText shouldNot be("")
         button1.getText should be(button2.getText)
@@ -159,7 +159,7 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
     }
     pair._1.watch()
     pair._2.watch()
-    pair._1.value should be(pair._2.value)
+    pair._1.get should be(pair._2.get)
   }
 
   "Pattern matching" in {
@@ -178,7 +178,7 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
     }
 
     buttons.watch()
-    inside(buttons.value) {
+    inside(buttons.get) {
       case Seq(button1, button2) =>
         button1.getText shouldNot be("")
         button1.getText should be(button2.getText)
@@ -198,7 +198,7 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
     }
 
     bs.watch()
-    inside(bs.value) {
+    inside(bs.get) {
       case (b, s) =>
         b.getText should be("My Button")
         s should be("My Button")
@@ -214,7 +214,7 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
       </Button>
     }
     button.watch()
-    button.value.getText should be("   ")
+    button.get.getText should be("   ")
   }
 
   "empty text for string property" in {
@@ -226,7 +226,7 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
       </Button>
     }
     button.watch()
-    button.value.getText should be("")
+    button.get.getText should be("")
   }
 
   "spaces for boolean property" in {
@@ -249,7 +249,7 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
     }
     vbox.watch()
     import scala.collection.JavaConverters._
-    vbox.value.getChildren.asScala should be(empty)
+    vbox.get.getChildren.asScala should be(empty)
   }
 
   "Constrants for repeated property" in {
@@ -263,7 +263,7 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
     }
     vbox.watch()
     import scala.collection.JavaConverters._
-    vbox.value.getChildren.asScala should be(empty)
+    vbox.get.getChildren.asScala should be(empty)
   }
 
   "fx:value" in {
@@ -276,7 +276,7 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
     }
 
     button.watch()
-    button.value.getText should be("My Button")
+    button.get.getText should be("My Button")
 
   }
 
@@ -296,7 +296,7 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
 
     vbox.watch()
 
-    inside(vbox.value.getChildren.asScala) {
+    inside(vbox.get.getChildren.asScala) {
       case Seq(button: javafx.scene.control.Button) =>
         button.getText should be("My Button")
     }
@@ -311,7 +311,7 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
 
     vbox.watch()
 
-    vbox.value should be(a[javafx.scene.layout.VBox])
+    vbox.get should be(a[javafx.scene.layout.VBox])
   }
 
   "two VBoxes" in {
@@ -323,7 +323,7 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
 
     vbox.watch()
 
-    inside(vbox.value) {
+    inside(vbox.get) {
       case Seq(vbox0, vbox1) =>
         vbox0 should be(a[javafx.scene.layout.VBox])
         vbox1 should be(a[javafx.scene.layout.VBox])
@@ -338,7 +338,7 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
 
     vbox.watch()
 
-    vbox.value should be(a[javafx.scene.layout.VBox])
+    vbox.get should be(a[javafx.scene.layout.VBox])
   }
 
   "import and a VBox" in {
@@ -349,7 +349,7 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
 
     vbox.watch()
 
-    vbox.value should be(a[javafx.scene.layout.VBox])
+    vbox.get should be(a[javafx.scene.layout.VBox])
   }
 
   "import and two VBox" in {
@@ -361,7 +361,7 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
 
     vbox.watch()
 
-    inside(vbox.value) {
+    inside(vbox.get) {
       case Seq(vbox0, vbox1) =>
         vbox0 should be(a[javafx.scene.layout.VBox])
         vbox1 should be(a[javafx.scene.layout.VBox])
@@ -381,7 +381,7 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
 
     vbox.watch()
 
-    inside(vbox.value.getChildren.asScala) {
+    inside(vbox.get.getChildren.asScala) {
       case Seq(button) => {
         button should be(a[javafx.scene.control.Button])
       }
@@ -403,7 +403,7 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
 
     vbox.watch()
 
-    inside(vbox.value.getChildren.asScala) {
+    inside(vbox.get.getChildren.asScala) {
       case Seq(button) => {
         button should be(a[javafx.scene.control.Button])
       }
@@ -425,7 +425,7 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
 
     vbox.watch()
 
-    inside(vbox.value.getChildren.asScala) {
+    inside(vbox.get.getChildren.asScala) {
       case Seq(button) => {
         button should be(a[javafx.scene.control.Button])
       }
@@ -449,7 +449,7 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
 
     vbox.watch()
 
-    inside(vbox.value.getChildren.asScala) {
+    inside(vbox.get.getChildren.asScala) {
       case Seq(button) => {
         button should be(a[javafx.scene.control.Button])
       }
@@ -466,7 +466,7 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
 
     vbox.watch()
 
-    inside(vbox.value.getChildren.asScala) {
+    inside(vbox.get.getChildren.asScala) {
       case Seq(button) => {
         button should be(a[javafx.scene.control.Button])
       }
@@ -486,7 +486,7 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
 
     vbox.watch()
 
-    inside(vbox.value.getChildren.asScala) {
+    inside(vbox.get.getChildren.asScala) {
       case Seq(button0, button1, button2) => {
         button0 should be(a[javafx.scene.control.Button])
         button1 should be(a[javafx.scene.control.Button])
@@ -504,10 +504,10 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
       </Button>
     }
     button.watch()
-    button.value should be(a[javafx.scene.control.Button])
+    button.get should be(a[javafx.scene.control.Button])
 
     import scala.collection.JavaConverters._
-    button.value.getProperties.asScala should be(Map("foo" -> "123", "bar" -> "456"))
+    button.get.getProperties.asScala should be(Map("foo" -> "123", "bar" -> "456"))
 
   }
 
@@ -521,7 +521,7 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
       </ImageView>
     }
     imageView.watch()
-    imageView.value.getImage.isError should be(false)
+    imageView.get.getImage.isError should be(false)
   }
 
   "Empty Button" in {
@@ -546,7 +546,7 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
       </GridPane>
     }
     gridPane.watch()
-    inside(gridPane.value.getChildren.asScala) {
+    inside(gridPane.get.getChildren.asScala) {
       case Seq(label: Label) =>
         GridPane.getRowIndex(label) should be(2)
         GridPane.getColumnIndex(label) should be(3)
@@ -588,7 +588,7 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
 
     vbox.watch()
 
-    inside(vbox.value.getChildren.asScala) {
+    inside(vbox.get.getChildren.asScala) {
       case Seq(button0: javafx.scene.control.Button, button1: javafx.scene.control.Button) => {
         button0 shouldNot be(button1)
         button0.getText should be("Hello World")
@@ -618,7 +618,7 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
     }
 
     vbox.watch()
-    inside(vbox.value.getChildren.asScala) {
+    inside(vbox.get.getChildren.asScala) {
       case Seq(button: javafx.scene.control.Button) =>
         button.getText should be("Click Me!")
         button.getOnAction.handle(new ActionEvent)
@@ -642,7 +642,7 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
     }
 
     vbox.watch()
-    inside(vbox.value.getChildren.asScala) {
+    inside(vbox.get.getChildren.asScala) {
       case Seq(button: javafx.scene.control.Button) =>
         button.getText should be("Click Me!")
         button.getOnAction.handle(new ActionEvent)
@@ -692,7 +692,7 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
       }
     }
     vbox.watch()
-    inside(vbox.value.getChildren.asScala) {
+    inside(vbox.get.getChildren.asScala) {
       case Seq(b0: Button, b1: Button) =>
         b0.getText should be("first button")
         b1.getText should be("last button")
@@ -714,7 +714,7 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
 
     eventHandlers should be(empty)
 
-    inside(vbox.value.getChildren.asScala) {
+    inside(vbox.get.getChildren.asScala) {
       case Seq(b0: Button, b1: Button, b2: Button, b3: Button, b4: Button) =>
         b0.getText should be("first button")
         b1.getText should be("foo")
@@ -759,8 +759,8 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
     import javafx.scene.control.Button
     @fxml val button = <Button id="&lt; &lt; ">&gt; &gt;</Button>
     button.watch()
-    button.value.getId should be("< < ")
-    button.value.getText should be(">>")
+    button.get.getId should be("< < ")
+    button.get.getText should be(">>")
   }
 
   "issue 65" in {
@@ -772,7 +772,7 @@ final class fxmlTest extends FreeSpec with Matchers with Inside {
     }
 
     stringTable.watch()
-    stringTable.value.getItems.size should be(2)
+    stringTable.get.getItems.size should be(2)
   }
 
   override protected def withFixture(test: NoArgTest): Outcome = {

--- a/fxml/src/test/scala/com/thoughtworks/binding/NotJavaFXSpec.scala
+++ b/fxml/src/test/scala/com/thoughtworks/binding/NotJavaFXSpec.scala
@@ -10,7 +10,7 @@ final class NotJavaFXSpec extends FreeSpec with Matchers with Inside {
     import java.util._
     @fxml val random = <Random seed={1}/>
     random.watch()
-    random.value should be(a[Random])
-    random.value.nextInt should be(-1155869325)
+    random.get should be(a[Random])
+    random.get.nextInt should be(-1155869325)
   }
 }


### PR DESCRIPTION
252da6101fab2fbb3e54e40ead084029e5e18963 breaks source code backward-compatibility as https://travis-ci.org/ThoughtWorksInc/LatestEvent.scala/builds/553761447?utm_source=github_status&utm_medium=notification . This PR reverts 252da6101fab2fbb3e54e40ead084029e5e18963.

252da6101fab2fbb3e54e40ead084029e5e18963 breaks source code backward compatibility but not binary backward compatibility, because `value` was a `protected` method in `trait` in source code but it was actually  a `public` method in byte code. 252da6101fab2fbb3e54e40ead084029e5e18963 makes `value` be `public` in both source code and byte code.